### PR TITLE
New option to specify base release tag

### DIFF
--- a/packages/conventional-recommended-bump/README.md
+++ b/packages/conventional-recommended-bump/README.md
@@ -21,6 +21,7 @@ Got the idea from https://github.com/conventional-changelog/conventional-changel
       - [skipUnstable](#skipunstable)
       - [lernaPackage](#lernapackage)
       - [path](#path)
+      - [baseTag](#basetag)
     - [parserOpts](#parseropts)
     - [callback](#callback)
 - [License](#license)
@@ -132,6 +133,12 @@ For instance if your project contained a package named `conventional-changelog`,
 **Type:** `string`
 
 Specify the path to only calculate with git commits related to the path. If you want to calculate recommended bumps of packages in a [Lerna](https://lernajs.io/)-managed repository, `path` should be use along with `lernaPackage` for each of the package.
+
+##### baseTag
+
+**Type:** `string`
+
+Specify the release tag to use for analysing the commits. If not specified, the most recent semver tag will be chosen.
 
 #### parserOpts
 

--- a/packages/conventional-recommended-bump/cli.js
+++ b/packages/conventional-recommended-bump/cli.js
@@ -25,6 +25,7 @@ const cli = meow(`
       -v, --verbose                  Verbose output
       -l, --lerna-package            Recommend a bump for a specific lerna package (:pkg-name@1.0.0)
       -t, --tag-prefix               Tag prefix to consider when reading the tags
+      -bt --base-tag                 Base release tag
       --commit-path                  Recommend a bump scoped to a specific directory
       --skip-unstable                If given, unstable tags will be skipped, e.g., x.x.x-alpha.1, x.x.x-rc.2
 `, {
@@ -61,6 +62,9 @@ const cli = meow(`
     },
     'tag-prefix': {
       alias: 't'
+    },
+    'base-tag': {
+      alias: 'bt'
     }
   }
 })
@@ -69,7 +73,8 @@ const options = {
   path: cli.flags.commitPath,
   lernaPackage: cli.flags.lernaPackage,
   tagPrefix: cli.flags.tagPrefix,
-  skipUnstable: cli.flags.skipUnstable
+  skipUnstable: cli.flags.skipUnstable,
+  baseTag: cli.flags.baseTag
 }
 const flags = cli.flags
 const preset = flags.preset

--- a/packages/conventional-recommended-bump/test/index.spec.js
+++ b/packages/conventional-recommended-bump/test/index.spec.js
@@ -38,6 +38,10 @@ betterThanBefore.setups([
   () => { // 7
     exec('git tag my-package@1.0.0')
     gitDummyCommit(['feat: this should have been working'])
+  },
+  () => { // 8
+    exec('git tag v1.1.0')
+    gitDummyCommit(['feat: another commit'])
   }
 ])
 
@@ -330,6 +334,35 @@ describe('conventional-recommended-bump API', () => {
           done()
         }
       }, () => {})
+    })
+  })
+
+  describe('Option baseTag', () => {
+    it('should use provided tag to get commits', done => {
+      preparing(8)
+
+      conventionalRecommendedBump({
+        baseTag: 'v1.0.0',
+        whatBump: commits => {
+          assert.strictEqual(commits[0].type, 'feat')
+          assert.strictEqual(commits[0].header, 'feat: another commit')
+          assert.strictEqual(commits[3].type, 'feat')
+          assert.strictEqual(commits[3].header, 'feat: should not be taken into account')
+          assert.strictEqual(commits.length, 4)
+        }
+      }, {}, () => done())
+    })
+
+    it('should use latest tag to get commits if baseTag not provided', done => {
+      preparing(8)
+
+      conventionalRecommendedBump({
+        whatBump: commits => {
+          assert.strictEqual(commits[0].type, 'feat')
+          assert.strictEqual(commits[0].header, 'feat: another commit')
+          assert.strictEqual(commits.length, 1)
+        }
+      }, {}, () => done())
     })
   })
 })


### PR DESCRIPTION
This PR adds a new input option named `baseTag` to the conventional-recommended-bump package that enables users to select a base tag from which commits should be examined rather than always utilizing the most current tag (which is the default).

This provides the user the flexibility to not solely rely on `gitSemverTags` and instead use a custom tag that they may have obtained using the GitHub API .