### PR TITLE
Export monorepo packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "engines": {
     "node": ">=10"
   },
-  "files": [],
+  "files": [
+    "scripts/install.sh",
+    "packages"
+  ],
   "homepage": "https://github.com/conventional-changelog/conventional-changelog#readme",
   "keywords": [
     "conventional-changelog",
@@ -17,7 +20,7 @@
     "generation"
   ],
   "license": "ISC",
-  "main": "",
+  "main": "packages/conventional-recommended-bump",
   "name": "conventional-changelog-monorepo",
   "private": true,
   "renovate": {
@@ -29,6 +32,10 @@
       ":gitSignOff",
       ":preserveSemverRanges"
     ]
+  },
+  "exports": {
+    "./packages/conventional-changelog-conventionalcommits": "./packages/conventional-changelog-conventionalcommits/index.js",
+    "./packages/conventional-recommended-bump": "./packages/conventional-recommended-bump/index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "generation"
   ],
   "license": "ISC",
-  "main": "packages/conventional-recommended-bump",
+  "main": "",
   "name": "conventional-changelog-monorepo",
   "private": true,
   "renovate": {
@@ -34,8 +34,8 @@
     ]
   },
   "exports": {
-    "./packages/conventional-changelog-conventionalcommits": "./packages/conventional-changelog-conventionalcommits/index.js",
-    "./packages/conventional-recommended-bump": "./packages/conventional-recommended-bump/index.js"
+    "./conventional-changelog-conventionalcommits": "./packages/conventional-changelog-conventionalcommits/index.js",
+    "./conventional-recommended-bump": "./packages/conventional-recommended-bump/index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/conventional-recommended-bump/package.json
+++ b/packages/conventional-recommended-bump/package.json
@@ -19,6 +19,7 @@
   "engines": {
     "node": ">=10"
   },
+  "main": "index.js",
   "files": [
     "index.js",
     "cli.js",


### PR DESCRIPTION
This PR makes some changes to export the packages in this monorepo. This is required because these forked packages can no longer be installed from NPM.